### PR TITLE
Move setting the Discogs key/secret out of http code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_executable(dcue
   main.cpp
   ${HTTP_EXTRA_SOURCES}
 )
-target_include_directories(dcue PRIVATE ${HTTP_INCLUDES})
+target_include_directories(dcue PRIVATE ${HTTP_INCLUDES} ${CMAKE_SOURCE_DIR})
 target_link_libraries(dcue ${HTTP_LIBS})
 
 if(DEFINED ENV{DCUE_APP_KEY} AND DEFINED ENV{DCUE_APP_SECRET} AND

--- a/appkey.h.in
+++ b/appkey.h.in
@@ -4,20 +4,28 @@
 #include <array>
 #include <string>
 
+#include "http_types.h"
+
 struct discogs_key {
+  static HttpHeader getHeader() {
+    auto key = get();
+    std::string value = "Discogs key=" + key.key + ", secret=" + key.secret;
+    return HttpHeader{"Authorization", std::move(value)};
+  }
+
+private:
   const std::string key;
   const std::string secret;
+
+  discogs_key(std::string&& key, std::string&& secret)
+      : key(key), secret(secret) {
+  }
 
   static discogs_key get() {
     static constexpr const char key[] = "$ENV{DCUE_APP_KEY}";
     static constexpr const char secret[] = "$ENV{DCUE_APP_SECRET}";
-    return discogs_key(descramble(key, sizeof(key)),
-                       descramble(secret, sizeof(secret)));
-  }
-
-private:
-  discogs_key(std::string&& key, std::string&& secret)
-      : key(key), secret(secret) {
+    return discogs_key(descramble(key, sizeof(key) - 1),
+                       descramble(secret, sizeof(secret) - 1));
   }
 
   static std::string descramble(const char* data, std::size_t len) {
@@ -28,8 +36,8 @@ private:
         static_cast<unsigned char>((xorkey >> 16) & 0xff),
         static_cast<unsigned char>((xorkey >> 24) & 0xff)};
     std::string rv;
-    rv.reserve(len - 1);
-    for (std::size_t i = 0; i < len - 1; ++i) {
+    rv.reserve(len);
+    for (std::size_t i = 0; i < len; ++i) {
       rv.push_back(data[i] ^ xorkey_b[i % xorkey_b.size()]);
     }
     return rv;

--- a/discogs.cpp
+++ b/discogs.cpp
@@ -12,6 +12,10 @@
 
 #include "discogs.h"
 
+#ifdef DCUE_OFFICIAL_BUILD
+#include "appkey.h"
+#endif
+
 bool DiscogsReleaseRequest::send(const std::string& rel_id, nlohmann::json& out,
                                  const bool is_master) {
   HttpGet req;
@@ -20,6 +24,9 @@ bool DiscogsReleaseRequest::send(const std::string& rel_id, nlohmann::json& out,
   } else {
     req.set_resource("/releases/" + rel_id);
   }
+#ifdef DCUE_OFFICIAL_BUILD
+  req.add_header(discogs_key::getHeader());
+#endif
   req.send("https://api.discogs.com", res);
   if (success()) {
     out = nlohmann::json::parse(res.body);

--- a/http_curl.cpp
+++ b/http_curl.cpp
@@ -7,10 +7,6 @@
 
 #include "string_utility.h"
 
-#ifdef DCUE_OFFICIAL_BUILD
-#include "appkey.h"
-#endif
-
 namespace {
 struct CurlDeleter {
   void operator()(void* c) const {

--- a/http_curl.cpp
+++ b/http_curl.cpp
@@ -61,12 +61,8 @@ void HttpGetCurl::global_deinit() {
   ::curl_global_cleanup();
 }
 
-void HttpGetCurl::add_header(const std::string& name,
-                             const std::string& value) {
-  HttpHeader h;
-  h.name = name;
-  h.value = value;
-  headers.push_back(h);
+void HttpGetCurl::add_header(HttpHeader&& header) {
+  headers.emplace_back(header);
 }
 
 void HttpGetCurl::set_resource(const std::string& res) {
@@ -88,16 +84,6 @@ bool HttpGetCurl::send(const std::string& hostname, HttpResponse& out) const {
     list = ::curl_slist_append(list, fullHeader.c_str());
   }
   list = ::curl_slist_append(list, "User-Agent: " USER_AGENT);
-#ifdef DCUE_OFFICIAL_BUILD
-  {
-    auto key = discogs_key::get();
-    std::string auth_hdr("Authorization: Discogs key=");
-    auth_hdr.append(key.key);
-    auth_hdr.append(", secret=");
-    auth_hdr.append(key.secret);
-    list = ::curl_slist_append(list, auth_hdr.c_str());
-  }
-#endif
   ::curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, list);
 
   ::curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &out.body);

--- a/http_curl.h
+++ b/http_curl.h
@@ -12,7 +12,7 @@ class HttpGetCurl {
 public:
   static void global_init();
   static void global_deinit();
-  void add_header(const std::string& name, const std::string& value);
+  void add_header(HttpHeader&& header);
   void set_resource(const std::string& res);
   bool send(const std::string& hostname, HttpResponse& out) const;
 };

--- a/http_wininet.h
+++ b/http_wininet.h
@@ -12,7 +12,7 @@ class HttpGetWinInet {
 public:
   static void global_init();
   static void global_deinit();
-  void add_header(const std::string& name, const std::string& value);
+  void add_header(HttpHeader&& header);
   void set_resource(const std::string& res);
   bool send(const std::string& hostname, HttpResponse& out) const;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -67,6 +67,8 @@ bool fetch(const std::string& id, nlohmann::json& data,
   return req.send(id, data, is_master);
 }
 
+#ifdef DCUE_OFFICIAL_BUILD
+#include "appkey.h"
 void get_cover(const nlohmann::json& toplevel, const std::string& fname) {
   auto it = toplevel.find("images");
   if (it == toplevel.end()) {
@@ -94,6 +96,7 @@ void get_cover(const nlohmann::json& toplevel, const std::string& fname) {
 
   HttpGet g;
   g.set_resource((*imageIt).at("uri"));
+  g.add_header(discogs_key::getHeader());
   HttpResponse out;
   if (!g.send("", out)) {
     std::cerr << "Image request failed\n";
@@ -108,6 +111,7 @@ void get_cover(const nlohmann::json& toplevel, const std::string& fname) {
   outfile.write(reinterpret_cast<const char*>(out.body.data()),
                 out.body.size());
 }
+#endif
 }
 
 int main(int argc, char* argv[]) {
@@ -122,9 +126,9 @@ int main(int argc, char* argv[]) {
     return 0;
   }
 
+#ifdef DCUE_OFFICIAL_BUILD
   bool do_cover = false;
   std::string cover_fname = "cover.jpg";
-#ifdef DCUE_OFFICIAL_BUILD
   {
     const auto cover_arg = std::find_if(argv, argv_end, [](char* str) {
       return ::strcmp(str, "--cover") == 0;
@@ -169,9 +173,11 @@ int main(int argc, char* argv[]) {
 
   try {
     generate(discogs_data, argv[2]);
+#ifdef DCUE_OFFICIAL_BUILD
     if (do_cover) {
       get_cover(discogs_data, cover_fname);
     }
+#endif
     return 0;
   } catch (const std::exception& e) {
     std::cerr << e.what() << '\n';


### PR DESCRIPTION
There's no real reason to keep it there, and there's finally a reason to implement `add_header` in http classes.